### PR TITLE
add cmd /c in open_url for Windows

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,7 +45,7 @@ end
 ## Open a url using our heuristic
 function open_url(url::String) 
     @osx_only     run(`open $url`)
-    @windows_only run(`start $url`)
+    @windows_only run(`cmd /c start $url`)
     @linux_only   run(`xdg-open $url`)
 end
         


### PR DESCRIPTION
This was necessary for opening a chart in the browser to work for me (64 bit Windows 7, Julia 0.3.0-prerelease) otherwise I was getting `ERROR: could not spawn `start 'C:\Users\Tony\AppData\Local\Temp\julia2.html'`: no such file or directory (ENOENT)`.

Separate issue, but the version of this package that's currently tagged in Metadata does not work due to changes in DataFrames. I had to do `Pkg.checkout("GoogleCharts")` but that extra step isn't always obvious to new users.
